### PR TITLE
fix: voting power fix (when chest is unstaked and staked again)

### DIFF
--- a/contracts/Chest.sol
+++ b/contracts/Chest.sol
@@ -578,7 +578,7 @@ contract Chest is ERC721, Ownable, VestingLibChest, ReentrancyGuard {
             // regular chest
             uint120 booster = calculateBooster(vestingPosition, uint48(timestamp));
             power =
-                (booster * vestingPosition.totalVestedAmount * regularFreezingTime) /
+                (booster * (vestingPosition.totalVestedAmount - vestingPosition.releasedAmount) * regularFreezingTime) /
                 (MIN_STAKING_AMOUNT * DECIMALS); // @dev scaling because of minimum staking amount and booster
         } else {
             // special chest
@@ -602,7 +602,7 @@ contract Chest is ERC721, Ownable, VestingLibChest, ReentrancyGuard {
             // apply nerf parameter
             uint8 nerfParameter = vestingPosition.nerfParameter;
             power =
-                (vestingPosition.totalVestedAmount *
+                ((vestingPosition.totalVestedAmount - vestingPosition.releasedAmount) *
                     totalFreezingTimeInWeeks *
                     nerfParameter) /
                 (10 * MIN_STAKING_AMOUNT); // @dev scaling because of minimum staking amount

--- a/contracts/utils/VestingLibChest.sol
+++ b/contracts/utils/VestingLibChest.sol
@@ -50,8 +50,7 @@ abstract contract VestingLibChest {
     function releasableAmount(
         uint256 vestingIndex
     ) public view returns (uint256) {
-        VestingPosition memory vestingPosition = vestingPositions[vestingIndex];
-        return vestedAmount(vestingIndex) - vestingPosition.releasedAmount;
+        return vestedAmount(vestingIndex);
     }
 
     function vestedAmount(
@@ -67,11 +66,11 @@ abstract contract VestingLibChest {
             block.timestamp >=
             vestingPosition_.cliffTimestamp + vestingPosition_.vestingDuration
         ) {
-            vestedAmount_ = vestingPosition_.totalVestedAmount;
+            vestedAmount_ = vestingPosition_.totalVestedAmount - vestingPosition_.releasedAmount;
         } else {
             unchecked {
                 vestedAmount_ =
-                    (vestingPosition_.totalVestedAmount *
+                    ((vestingPosition_.totalVestedAmount - vestingPosition_.releasedAmount) *
                         (block.timestamp - vestingPosition_.cliffTimestamp)) /
                     vestingPosition_.vestingDuration;
             }

--- a/test/fixtures/unit__InvestorDistribution.ts
+++ b/test/fixtures/unit__InvestorDistribution.ts
@@ -36,9 +36,6 @@ export async function deployInvestorDistributionFixture(): Promise<UnitInvestorD
   const ChestFactory: Chest__factory = await ethers.getContractFactory("Chest");
   const chest: Chest = await ChestFactory.deploy(
     jellyToken.address,
-    investorDistribution.address,
-    investorDistribution.address,
-    0,
     0,
     0,
     deployer.address,

--- a/test/unit/investor_distribution/InvestorDistribution.spec.ts
+++ b/test/unit/investor_distribution/InvestorDistribution.spec.ts
@@ -393,13 +393,14 @@ describe("InvestorDistribution", function () {
           const cliffTimestamp = BigNumber.from(
             timestamps[Math.floor(i / 10)] + FREEZING_PERIOD
           );
+          const boosterTimestamp = BigNumber.from(timestamps[Math.floor(i / 10)]);
 
           const vestingPosition = await chest.getVestingPosition(i);
           expect(vestingPosition[0]).to.equal(totalVestedAmount);
           expect(vestingPosition[1]).to.equal(releasedAmount);
           expect(vestingPosition[2]).to.equal(cliffTimestamp);
-          expect(vestingPosition[3]).to.equal(VESTING_DURATION);
-          expect(vestingPosition[4]).to.equal(FREEZING_PERIOD);
+          expect(vestingPosition[3]).to.equal(boosterTimestamp);
+          expect(vestingPosition[4]).to.equal(VESTING_DURATION);
           expect(vestingPosition[5]).to.equal(INITIAL_BOOSTER);
           expect(vestingPosition[6]).to.equal(NERF_PARAMETER);
         }


### PR DESCRIPTION
voting power fix (when chest is unstaked and staked again)
It was using `totalVestedAmount` not `totalVestedAmount - totalVestedAmount` in voting power calculations.
Also fixed releasable amount (same issue)